### PR TITLE
Feature/minor spec improvements

### DIFF
--- a/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
+++ b/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
@@ -80,7 +80,20 @@ describe(@"TRSNetworkAgent+Trustbadge", ^{
 
         context(@"on failure", ^{
 
-            it(@"executes the failuer block", ^{
+            beforeEach(^{
+                [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                    return [request.URL.absoluteString isEqualToString:@"http://localhost/foo/bar/baz"];
+                } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                    NSError *networkError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotConnectToHost userInfo:nil];
+                    return [OHHTTPStubsResponse responseWithError:networkError];
+                }];
+            });
+            
+            afterEach(^{
+                [OHHTTPStubs removeAllStubs];
+            });
+            
+            it(@"executes the failure block", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent getTrustbadgeForTrustedShopsID:@"error"
                                                   success:nil

--- a/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
+++ b/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
@@ -103,12 +103,22 @@ describe(@"TRSNetworkAgent+Trustbadge", ^{
                 });
             });
 
-            it(@"passes an error object", ^{
+            it(@"passes an error object with a 'NSURLErrorDomain' error domain", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent getTrustbadgeForTrustedShopsID:@"error"
                                                   success:nil
                                                   failure:^(NSError *error) {
                                                       expect(error.domain).to.equal(@"NSURLErrorDomain");
+                                                      done();
+                                                  }];
+                });
+            });
+
+            it(@"passes an error object with a 'NSURLErrorCannotConnectToHost' error code", ^{
+                waitUntil(^(DoneCallback done) {
+                    [agent getTrustbadgeForTrustedShopsID:@"error"
+                                                  success:nil
+                                                  failure:^(NSError *error) {
                                                       expect(error.code).to.equal(NSURLErrorCannotConnectToHost);
                                                       done();
                                                   }];

--- a/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
+++ b/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
@@ -216,6 +216,17 @@ describe(@"TRSNetworkAgent+Trustbadge", ^{
                         [OHHTTPStubs removeAllStubs];
                     });
 
+                    it(@"passes a data object", ^{
+                        waitUntil(^(DoneCallback done) {
+                            [agent GET:@"/foo/bar/baz"
+                               success:nil
+                               failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
+                                   expect(data).to.equal([[NSString stringWithFormat:@"not a HTTP status code"] dataUsingEncoding:NSUTF8StringEncoding]);
+                                   done();
+                               }];
+                        });
+                    });
+
                     it(@"passes a custom error code", ^{
                         waitUntil(^(DoneCallback done) {
                             [agent getTrustbadgeForTrustedShopsID:@"error"

--- a/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
+++ b/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
@@ -43,7 +43,7 @@ describe(@"TRSNetworkAgent+Trustbadge", ^{
 
             beforeEach(^{
                 [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-                    return YES;
+                    return [request.URL.absoluteString isEqualToString:@"http://localhost/rest/public/v2/shops/123/quality"];
                 } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
                     return [OHHTTPStubsResponse responseWithData:[[NSString stringWithFormat:@"success"] dataUsingEncoding:NSUTF8StringEncoding]
                                                       statusCode:200

--- a/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
+++ b/Example/Tests/TRSNetworkAgent+TrustbadgeSpec.m
@@ -108,7 +108,8 @@ describe(@"TRSNetworkAgent+Trustbadge", ^{
                     [agent getTrustbadgeForTrustedShopsID:@"error"
                                                   success:nil
                                                   failure:^(NSError *error) {
-                                                      expect(error).notTo.beNil();
+                                                      expect(error.domain).to.equal(@"NSURLErrorDomain");
+                                                      expect(error.code).to.equal(NSURLErrorCannotConnectToHost);
                                                       done();
                                                   }];
                 });

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -2,7 +2,6 @@
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import <Specta/Specta.h>
 
-
 SpecBegin(TRSNetworkAgent)
 
 describe(@"TRSNetworkAgent", ^{
@@ -32,6 +31,13 @@ describe(@"TRSNetworkAgent", ^{
 
         it(@"has the correct base URL", ^{
             expect([TRSNetworkAgent sharedAgent].baseURL).to.equal([NSURL URLWithString:@"https://api.trustedshops.com/"]);
+        });
+        
+        it(@"returns the same instance", ^{
+            TRSNetworkAgent *agent1 = [TRSNetworkAgent sharedAgent];
+            TRSNetworkAgent *agent2 = [TRSNetworkAgent sharedAgent];
+            
+            expect(agent1).to.equal(agent2);
         });
 
     });

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -130,6 +130,7 @@ describe(@"TRSNetworkAgent", ^{
                        success:nil
                        failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(error.domain).to.equal(@"NSURLErrorDomain");
+                           expect(error.code).to.equal(NSURLErrorCannotConnectToHost);
                            done();
                        }];
                 });

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -119,6 +119,7 @@ describe(@"TRSNetworkAgent", ^{
                        success:nil
                        failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(data).notTo.beNil();
+                           expect(data.length).to.equal(0);
                            done();
                        }];
                 });

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -119,18 +119,38 @@ describe(@"TRSNetworkAgent", ^{
                        success:nil
                        failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(data).notTo.beNil();
+                           done();
+                       }];
+                });
+            });
+
+            it(@"passes a data object with a length of 0", ^{
+                waitUntil(^(DoneCallback done) {
+                    [agent GET:@"/foo/bar/baz"
+                       success:nil
+                       failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(data.length).to.equal(0);
                            done();
                        }];
                 });
             });
 
-            it(@"passes an error object", ^{
+            it(@"passes an error object with a 'NSURLErrorDomain' error domain", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent GET:@"/foo/bar/baz"
                        success:nil
                        failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(error.domain).to.equal(@"NSURLErrorDomain");
+                           done();
+                       }];
+                });
+            });
+
+            it(@"passes an error object with a 'NSURLErrorCannotConnectToHost' error code", ^{
+                waitUntil(^(DoneCallback done) {
+                    [agent GET:@"/foo/bar/baz"
+                       success:nil
+                       failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
                            expect(error.code).to.equal(NSURLErrorCannotConnectToHost);
                            done();
                        }];

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -90,6 +90,19 @@ describe(@"TRSNetworkAgent", ^{
 
         context(@"on failure", ^{
 
+            beforeEach(^{
+                [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+                    return [request.URL.absoluteString isEqualToString:@"http://localhost/foo/bar/baz"];
+                } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+                    NSError *networkError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotConnectToHost userInfo:nil];
+                    return [OHHTTPStubsResponse responseWithError:networkError];
+                }];
+            });
+            
+            afterEach(^{
+                [OHHTTPStubs removeAllStubs];
+            });
+            
             it(@"calls the failure block", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent GET:@"/foo/bar/baz"

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -79,7 +79,7 @@ describe(@"TRSNetworkAgent", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent GET:@"/foo/bar/baz"
                        success:^(NSData *data){
-                           expect(data).notTo.beNil();
+                           expect(data).to.equal([[NSString stringWithFormat:@"success"] dataUsingEncoding:NSUTF8StringEncoding]);
                            done();
                        }
                        failure:nil];
@@ -152,6 +152,17 @@ describe(@"TRSNetworkAgent", ^{
 
                 afterEach(^{
                     [OHHTTPStubs removeAllStubs];
+                });
+
+                it(@"passes a data object", ^{
+                    waitUntil(^(DoneCallback done) {
+                        [agent GET:@"/foo/bar/baz"
+                           success:nil
+                           failure:^(NSData *data, NSHTTPURLResponse *response, NSError *error) {
+                               expect(data).to.equal([[NSString stringWithFormat:@"not found"] dataUsingEncoding:NSUTF8StringEncoding]);
+                               done();
+                           }];
+                    });
                 });
 
                 it(@"passes a response object", ^{

--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -53,7 +53,7 @@ describe(@"TRSNetworkAgent", ^{
 
             beforeEach(^{
                 [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-                    return YES;
+                    return [request.URL.absoluteString isEqualToString:@"http://localhost/foo/bar/baz"];
                 } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
                     return [OHHTTPStubsResponse responseWithData:[[NSString stringWithFormat:@"success"] dataUsingEncoding:NSUTF8StringEncoding]
                                                       statusCode:200
@@ -139,7 +139,7 @@ describe(@"TRSNetworkAgent", ^{
 
                 beforeEach(^{
                     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-                        return YES;
+                        return [request.URL.absoluteString isEqualToString:@"http://localhost/foo/bar/baz"];
                     }
                                         withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
                                             return [OHHTTPStubsResponse responseWithData:[[NSString stringWithFormat:@"not found"] dataUsingEncoding:NSUTF8StringEncoding]


### PR DESCRIPTION
Hey there, I just added some minor improvements to the specs:
- stub failing requests explicitly (this worked before because an unstubbed request went against `localhost`)
- only stub the request we expect in `-stubRequestsPassingTest:` (so we are sure the URLs are correct)
- add some additional test cases
