### PR TITLE
Accept JSON

### DIFF
--- a/Example/Tests/TRSNetworkAgentSpec.m
+++ b/Example/Tests/TRSNetworkAgentSpec.m
@@ -59,6 +59,13 @@ describe(@"TRSNetworkAgent", ^{
                 [OHHTTPStubs removeAllStubs];
             });
 
+            it(@"accepts JSON", ^{
+                NSURLSessionDataTask *task = (NSURLSessionDataTask *)[agent GET:@"foo/bar/baz" success:nil failure:nil];
+                NSDictionary *headerDictionary = task.originalRequest.allHTTPHeaderFields;
+
+                expect(headerDictionary).to.beSupersetOf(@{@"Accept" : @"application/json"});
+            });
+
             it(@"calls the success block", ^{
                 waitUntil(^(DoneCallback done) {
                     [agent GET:@"foo/bar/baz"

--- a/Pod/Classes/TRSNetworkAgent.m
+++ b/Pod/Classes/TRSNetworkAgent.m
@@ -52,7 +52,9 @@ static NSString * const TRSNetworkAgentBaseURL = @"https://api.trustedshops.com/
     };
 
     NSURL *requestURL = [NSURL URLWithString:path relativeToURL:self.baseURL];
-    NSURLSessionDataTask *task = [session dataTaskWithURL:requestURL completionHandler:completion];
+    NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:requestURL];
+    mutableRequest.allHTTPHeaderFields = @{@"Accept" : @"application/json"};
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:[mutableRequest copy] completionHandler:completion];
     [task resume];
 
     return task;


### PR DESCRIPTION
Setting `allHTTPHeaderFields` on a `NSURLSessionConfiguration` object
will not pass the header fields to a data task object. Fetching
`allHTTPHeaderFields` from a `NSURLRequest` will return `nil`.

Because of this behavior, this patch refactors `GET:success:failure:` to use
`dataTaskWithRequest:completionHandler:` instead of
`dataTaskWithURL:completionHandler:` as a workaround. Setting the header fields
on a `NSURLRequest` will pass the header fields to a `NSURLRequest` object.
