### PR TITLE
Fix Rating

### DIFF
--- a/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
+++ b/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
@@ -1,0 +1,149 @@
+#import "NSNumberFormatter+TRSFormatter.h"
+#import <OCMock/OCMock.h>
+#import <Specta/Specta.h>
+
+
+SpecBegin(NSNumberFormatter_TRSFormatter)
+
+describe(@"NSNumberFormatter+TRSFormatter", ^{
+
+    __block NSNumber *rating;
+    beforeAll(^{
+        rating = @4.42;
+    });
+
+    afterAll(^{
+        rating = nil;
+    });
+
+    sharedExamplesFor(@"integer digits", ^(NSDictionary *data) {
+
+        it(@"it formats the number with one integer digit", ^{
+            expect(data[@"formattedNumberString"]).to.equal(@"4");
+        });
+
+    });
+
+    sharedExamplesFor(@"fraction digits", ^(NSDictionary *data) {
+
+        it(@"it formats the number with two fraction digits", ^{
+            expect(data[@"formattedNumberString"]).to.equal(@"42");
+        });
+
+    });
+
+    describe(@"+trs_trustbadgeRatingFormatter", ^{
+
+        context(@"for en_US locale", ^{
+
+            __block id localeMock;
+            before(^{
+                NSLocale *usLocale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
+                localeMock = OCMClassMock([NSLocale class]);
+                OCMStub([localeMock currentLocale]).andReturn(usLocale);
+            });
+
+            after(^{
+                localeMock = nil;
+            });
+
+            itShouldBehaveLike(@"integer digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
+            });
+
+            itShouldBehaveLike(@"fraction digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
+            });
+
+            it(@"formats the number for the current locale", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                expect(formattedNumberString).to.equal(@"4.42");
+            });
+
+        });
+
+        context(@"for de_DE locale", ^{
+
+            __block id localeMock;
+            before(^{
+                NSLocale *deLocale = [NSLocale localeWithLocaleIdentifier:@"de_DE"];
+                localeMock = OCMClassMock([NSLocale class]);
+                OCMStub([localeMock currentLocale]).andReturn(deLocale);
+            });
+
+            after(^{
+                localeMock = nil;
+            });
+
+            itShouldBehaveLike(@"integer digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] firstObject]};
+            });
+
+            itShouldBehaveLike(@"fraction digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] lastObject]};
+            });
+
+            it(@"formats the number for the current locale", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                expect(formattedNumberString).to.equal(@"4,42");
+            });
+
+        });
+
+        context(@"for es_ES locale", ^{
+
+            __block id localeMock;
+            before(^{
+                NSLocale *esLocale = [NSLocale localeWithLocaleIdentifier:@"es_ES"];
+                localeMock = OCMClassMock([NSLocale class]);
+                OCMStub([localeMock currentLocale]).andReturn(esLocale);
+            });
+
+            after(^{
+                localeMock = nil;
+            });
+
+            itShouldBehaveLike(@"integer digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] firstObject]};
+            });
+
+            itShouldBehaveLike(@"fraction digits", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] lastObject]};
+            });
+
+            it(@"formats the number for the current locale", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                expect(formattedNumberString).to.equal(@"4,42");
+            });
+
+        });
+
+    });
+
+});
+
+SpecEnd

--- a/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
+++ b/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
@@ -16,6 +16,14 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
         rating = nil;
     });
 
+    sharedExamplesFor(@"decimal seperator", ^(NSDictionary *data) {
+
+        it(@"it uses a `.` as a decimal seperator", ^{
+            expect(data[@"formattedNumberString"]).to.equal(@"4.42");
+        });
+
+    });
+
     sharedExamplesFor(@"integer digits", ^(NSDictionary *data) {
 
         it(@"it formats the number with one integer digit", ^{
@@ -47,6 +55,13 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
                 localeMock = nil;
             });
 
+            itShouldBehaveLike(@"decimal seperator", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : formattedNumberString};
+            });
+
             itShouldBehaveLike(@"integer digits", ^{
                 NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
@@ -59,13 +74,6 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
-            });
-
-            it(@"formats the number for the current locale", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                expect(formattedNumberString).to.equal(@"4.42");
             });
 
         });
@@ -83,25 +91,25 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
                 localeMock = nil;
             });
 
+            itShouldBehaveLike(@"decimal seperator", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : formattedNumberString};
+            });
+
             itShouldBehaveLike(@"integer digits", ^{
                 NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] firstObject]};
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
             });
 
             itShouldBehaveLike(@"fraction digits", ^{
                 NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] lastObject]};
-            });
-
-            it(@"formats the number for the current locale", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                expect(formattedNumberString).to.equal(@"4,42");
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
             });
 
         });
@@ -119,25 +127,25 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
                 localeMock = nil;
             });
 
+            itShouldBehaveLike(@"decimal seperator", ^{
+                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+                NSString *formattedNumberString = [formatter stringFromNumber:rating];
+
+                return @{@"formattedNumberString" : formattedNumberString};
+            });
+
             itShouldBehaveLike(@"integer digits", ^{
                 NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] firstObject]};
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
             });
 
             itShouldBehaveLike(@"fraction digits", ^{
                 NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@","] lastObject]};
-            });
-
-            it(@"formats the number for the current locale", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                expect(formattedNumberString).to.equal(@"4,42");
+                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
             });
 
         });

--- a/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
+++ b/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
@@ -42,6 +42,17 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
 
     describe(@"+trs_trustbadgeRatingFormatter", ^{
 
+        it(@"returns a `NSNumberFormatter` object", ^{
+            NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+            expect(formatter).to.beKindOf([NSNumberFormatter class]);
+        });
+
+        it(@"returns the same `NSNumberFormatter` object", ^{
+            NSNumberFormatter *aFormatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+            NSNumberFormatter *otherFormatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
+            expect(aFormatter).to.equal(otherFormatter);
+        });
+
         context(@"for en_US locale", ^{
 
             __block id localeMock;

--- a/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
+++ b/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
@@ -7,12 +7,15 @@ SpecBegin(NSNumberFormatter_TRSFormatter)
 
 describe(@"NSNumberFormatter+TRSFormatter", ^{
 
+    __block NSNumberFormatter *formatter;
     __block NSNumber *rating;
     beforeAll(^{
+        formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
         rating = @4.42;
     });
 
     afterAll(^{
+        formatter = nil;
         rating = nil;
     });
 
@@ -43,14 +46,12 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
     describe(@"+trs_trustbadgeRatingFormatter", ^{
 
         it(@"returns a `NSNumberFormatter` object", ^{
-            NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
             expect(formatter).to.beKindOf([NSNumberFormatter class]);
         });
 
         it(@"returns the same `NSNumberFormatter` object", ^{
-            NSNumberFormatter *aFormatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
             NSNumberFormatter *otherFormatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-            expect(aFormatter).to.equal(otherFormatter);
+            expect(formatter).to.equal(otherFormatter);
         });
 
         context(@"for en_US locale", ^{
@@ -67,21 +68,16 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
             });
 
             itShouldBehaveLike(@"decimal seperator", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : formattedNumberString};
+                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
             });
 
             itShouldBehaveLike(@"integer digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
             });
 
             itShouldBehaveLike(@"fraction digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
@@ -103,21 +99,16 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
             });
 
             itShouldBehaveLike(@"decimal seperator", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : formattedNumberString};
+                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
             });
 
             itShouldBehaveLike(@"integer digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
             });
 
             itShouldBehaveLike(@"fraction digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
@@ -139,21 +130,16 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
             });
 
             itShouldBehaveLike(@"decimal seperator", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : formattedNumberString};
+                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
             });
 
             itShouldBehaveLike(@"integer digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
             });
 
             itShouldBehaveLike(@"fraction digits", ^{
-                NSNumberFormatter *formatter = [NSNumberFormatter trs_trustbadgeRatingFormatter];
                 NSString *formattedNumberString = [formatter stringFromNumber:rating];
 
                 return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};

--- a/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
+++ b/Example/Tests/NSNumberFormatter+TRSFormatterSpec.m
@@ -19,30 +19,6 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
         rating = nil;
     });
 
-    sharedExamplesFor(@"decimal seperator", ^(NSDictionary *data) {
-
-        it(@"it uses a `.` as a decimal seperator", ^{
-            expect(data[@"formattedNumberString"]).to.equal(@"4.42");
-        });
-
-    });
-
-    sharedExamplesFor(@"integer digits", ^(NSDictionary *data) {
-
-        it(@"it formats the number with one integer digit", ^{
-            expect(data[@"formattedNumberString"]).to.equal(@"4");
-        });
-
-    });
-
-    sharedExamplesFor(@"fraction digits", ^(NSDictionary *data) {
-
-        it(@"it formats the number with two fraction digits", ^{
-            expect(data[@"formattedNumberString"]).to.equal(@"42");
-        });
-
-    });
-
     describe(@"+trs_trustbadgeRatingFormatter", ^{
 
         it(@"returns a `NSNumberFormatter` object", ^{
@@ -54,97 +30,18 @@ describe(@"NSNumberFormatter+TRSFormatter", ^{
             expect(formatter).to.equal(otherFormatter);
         });
 
-        context(@"for en_US locale", ^{
-
-            __block id localeMock;
-            before(^{
-                NSLocale *usLocale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-                localeMock = OCMClassMock([NSLocale class]);
-                OCMStub([localeMock currentLocale]).andReturn(usLocale);
-            });
-
-            after(^{
-                localeMock = nil;
-            });
-
-            itShouldBehaveLike(@"decimal seperator", ^{
-                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
-            });
-
-            itShouldBehaveLike(@"integer digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
-            });
-
-            itShouldBehaveLike(@"fraction digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
-            });
-
+        it(@"it uses a `.` as a decimal seperator", ^{
+            expect([formatter stringFromNumber:rating]).to.equal(@"4.42");
         });
 
-        context(@"for de_DE locale", ^{
-
-            __block id localeMock;
-            before(^{
-                NSLocale *deLocale = [NSLocale localeWithLocaleIdentifier:@"de_DE"];
-                localeMock = OCMClassMock([NSLocale class]);
-                OCMStub([localeMock currentLocale]).andReturn(deLocale);
-            });
-
-            after(^{
-                localeMock = nil;
-            });
-
-            itShouldBehaveLike(@"decimal seperator", ^{
-                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
-            });
-
-            itShouldBehaveLike(@"integer digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
-            });
-
-            itShouldBehaveLike(@"fraction digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
-            });
-
+        it(@"it formats the number with one integer digit", ^{
+            NSString *formattedNumberString = [[[formatter stringFromNumber:rating] componentsSeparatedByString:@"."] firstObject];
+            expect(formattedNumberString).to.equal(@"4");
         });
 
-        context(@"for es_ES locale", ^{
-
-            __block id localeMock;
-            before(^{
-                NSLocale *esLocale = [NSLocale localeWithLocaleIdentifier:@"es_ES"];
-                localeMock = OCMClassMock([NSLocale class]);
-                OCMStub([localeMock currentLocale]).andReturn(esLocale);
-            });
-
-            after(^{
-                localeMock = nil;
-            });
-
-            itShouldBehaveLike(@"decimal seperator", ^{
-                return @{@"formattedNumberString" : [formatter stringFromNumber:rating]};
-            });
-
-            itShouldBehaveLike(@"integer digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] firstObject]};
-            });
-
-            itShouldBehaveLike(@"fraction digits", ^{
-                NSString *formattedNumberString = [formatter stringFromNumber:rating];
-
-                return @{@"formattedNumberString" : [[formattedNumberString componentsSeparatedByString:@"."] lastObject]};
-            });
-
+        it(@"it formats the number with two fraction digits", ^{
+            NSString *formattedNumberString = [[[formatter stringFromNumber:rating] componentsSeparatedByString:@"."] lastObject];
+            expect(formattedNumberString).to.equal(@"42");
         });
 
     });

--- a/Example/Trustbadge.xcodeproj/project.pbxproj
+++ b/Example/Trustbadge.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		840B0C4A1B678CF400CB8E39 /* trustbadge.data in Resources */ = {isa = PBXBuildFile; fileRef = 840B0C491B678CF400CB8E39 /* trustbadge.data */; };
 		840B2B631B457135009E1D6D /* NSNumber+TRSRatingSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 840B2B611B45712C009E1D6D /* NSNumber+TRSRatingSpec.m */; };
 		845E62DA1B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 845E62D91B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m */; };
+		845E83DD1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 845E83DC1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m */; };
 		84795A4E1B5E41A30091EA49 /* TRSNetworkAgentSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84795A4C1B5E3EDA0091EA49 /* TRSNetworkAgentSpec.m */; };
 		84795A551B5E6B800091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84795A531B5E68EC0091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m */; };
 		848CFD731B82140A00CEEE1E /* Trustbadge-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 848CFD721B82140A00CEEE1E /* Trustbadge-Info.plist */; };
@@ -98,6 +99,7 @@
 		84177FC91B821D82002B2D08 /* pl-PL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pl-PL"; path = "pl-PL.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		84177FCA1B821D82002B2D08 /* pl-PL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pl-PL"; path = "pl-PL.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		845E62D91B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRSTrustbadgeSDKPrivatSpec.m; sourceTree = "<group>"; };
+		845E83DC1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumberFormatter+TRSFormatterSpec.m"; sourceTree = "<group>"; };
 		84795A4C1B5E3EDA0091EA49 /* TRSNetworkAgentSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRSNetworkAgentSpec.m; sourceTree = "<group>"; };
 		84795A531B5E68EC0091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TRSNetworkAgent+TrustbadgeSpec.m"; sourceTree = "<group>"; };
 		8485B6361B7A05AA00D22F1E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -182,6 +184,7 @@
 				845E62D91B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m */,
 				84D2C8781B678693005AE982 /* TRSTrustbadgeSpec.m */,
 				84C2BC2E1B78C25000F54653 /* TRSTrustbadgeViewSpec.m */,
+				845E83DC1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				840B2B631B457135009E1D6D /* NSNumber+TRSRatingSpec.m in Sources */,
+				845E83DD1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m in Sources */,
 				84795A4E1B5E41A30091EA49 /* TRSNetworkAgentSpec.m in Sources */,
 				845E62DA1B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m in Sources */,
 				84795A551B5E6B800091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m in Sources */,

--- a/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.h
+++ b/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+@interface NSNumberFormatter (TRSFormatter)
+
+/**
+ *  A number formatter for the Trustbadge. The integer part of the number will be shown with one digit and the fraction part will be shown with two integer digits.
+ *
+ *  @return Fully initialized `NSNumberFormatter` object.
+ */
++ (NSNumberFormatter *)trs_trustbadgeRatingFormatter;
+
+@end

--- a/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
+++ b/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
@@ -3,11 +3,15 @@
 @implementation NSNumberFormatter (TRSFormatter)
 
 + (NSNumberFormatter *)trs_trustbadgeRatingFormatter {
-    NSNumberFormatter *decimalFormatter = [[NSNumberFormatter alloc] init];
-    decimalFormatter.minimumIntegerDigits = 1;
-    decimalFormatter.minimumFractionDigits = 2;
-    decimalFormatter.maximumFractionDigits = 2;
-    decimalFormatter.decimalSeparator = @".";
+    static NSNumberFormatter *decimalFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        decimalFormatter = [[NSNumberFormatter alloc] init];
+        decimalFormatter.minimumIntegerDigits = 1;
+        decimalFormatter.minimumFractionDigits = 2;
+        decimalFormatter.maximumFractionDigits = 2;
+        decimalFormatter.decimalSeparator = @".";
+    });
 
     return decimalFormatter;
 }

--- a/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
+++ b/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
@@ -7,7 +7,7 @@
     decimalFormatter.minimumIntegerDigits = 1;
     decimalFormatter.minimumFractionDigits = 2;
     decimalFormatter.maximumFractionDigits = 2;
-    decimalFormatter.locale = [NSLocale currentLocale];
+    decimalFormatter.decimalSeparator = @".";
 
     return decimalFormatter;
 }

--- a/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
+++ b/Pod/Classes/Private/NSNumberFormatter+TRSFormatter.m
@@ -1,0 +1,15 @@
+#import "NSNumberFormatter+TRSFormatter.h"
+
+@implementation NSNumberFormatter (TRSFormatter)
+
++ (NSNumberFormatter *)trs_trustbadgeRatingFormatter {
+    NSNumberFormatter *decimalFormatter = [[NSNumberFormatter alloc] init];
+    decimalFormatter.minimumIntegerDigits = 1;
+    decimalFormatter.minimumFractionDigits = 2;
+    decimalFormatter.maximumFractionDigits = 2;
+    decimalFormatter.locale = [NSLocale currentLocale];
+
+    return decimalFormatter;
+}
+
+@end

--- a/Pod/Classes/Public/TRSTrustbadgeView.m
+++ b/Pod/Classes/Public/TRSTrustbadgeView.m
@@ -1,4 +1,5 @@
 #import "TRSTrustbadgeView.h"
+#import "NSNumberFormatter+TRSFormatter.h"
 #import "TRSErrors.h"
 #import "TRSNetworkAgent+Trustbadge.h"
 #import "TRSRatingView.h"
@@ -310,8 +311,8 @@ static CGFloat const TRSTrustbadgePadding = 10.0f;
 }
 
 - (NSAttributedString *)ratingStringForRating:(NSNumber *)rating {
-    NSString *maxRatingString = [NSString stringWithFormat:@"/%@", [self.decimalFormatter stringFromNumber:@5.0]];
-    NSString *ratingString = [NSString stringWithFormat:@"%@%@", [self.decimalFormatter stringFromNumber:rating], maxRatingString];
+    NSString *maxRatingString = [NSString stringWithFormat:@"/%@", [[NSNumberFormatter trs_trustbadgeRatingFormatter] stringFromNumber:@5.0]];
+    NSString *ratingString = [NSString stringWithFormat:@"%@%@", [[NSNumberFormatter trs_trustbadgeRatingFormatter] stringFromNumber:rating], maxRatingString];
 
     UIFont *normalFont = [UIFont fontWithName:@"Arial" size:14.0];
     NSDictionary *attributes = @{ NSFontAttributeName : normalFont };

--- a/Pod/Classes/Public/TRSTrustbadgeView.m
+++ b/Pod/Classes/Public/TRSTrustbadgeView.m
@@ -11,7 +11,6 @@
 @interface TRSTrustbadgeView ()
 
 @property (nonatomic, copy, readwrite) NSString *trustedShopsID;
-@property (nonatomic, strong) NSNumberFormatter *decimalFormatter;
 @property (nonatomic, strong) UIView *canvasView;
 @property (nonatomic, strong) UIImageView *triangleView;
 @property (nonatomic, strong) UIImage *triangleImage;
@@ -267,18 +266,6 @@ static CGFloat const TRSTrustbadgePadding = 10.0f;
                                                         multiplier:1.0f
                                                           constant:0.0f]];
     }
-}
-
-- (NSNumberFormatter *)decimalFormatter {
-    if (!_decimalFormatter) {
-        NSNumberFormatter *decimalFormatter = [[NSNumberFormatter alloc] init];
-        decimalFormatter.minimumIntegerDigits = 1;
-        decimalFormatter.minimumFractionDigits = 2;
-        decimalFormatter.maximumFractionDigits = 2;
-        _decimalFormatter = decimalFormatter;
-    }
-
-    return _decimalFormatter;
 }
 
 - (UIImage *)sealImage {


### PR DESCRIPTION
A Trustbadge rating is always displayed with the decimal separator `.` instead of the separator used by the system locale.

This pull request fixes this issue by extracting a local formatter property into a category and setting the `decimalSeparator` to the desired character.
