### PR TITLE
Add Spec for Internal Colors

### DIFF
--- a/Example/Tests/UIColor+TRSColorsInternalSpec.m
+++ b/Example/Tests/UIColor+TRSColorsInternalSpec.m
@@ -1,0 +1,115 @@
+#import "UIColor+TRSColorsInternal.h"
+#import <Specta/Specta.h>
+
+
+SpecBegin(UIColor_TRSColorsInternal)
+
+describe(@"UIColor+TRSColorsInternal", ^{
+
+    sharedExamplesFor(@"a UIColor object", ^(NSDictionary *data) {
+
+        it(@"returns an UIColor object", ^{
+            expect(data[@"object"]).to.beKindOf([UIColor class]);
+        });
+
+    });
+
+    describe(@"trs_ananas", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_ananas]};
+        });
+
+        it(@"returns the CI color 'ananas'", ^{
+            expect([UIColor trs_ananas]).to.equal([UIColor colorWithRed:1 green:0.862 blue:0.058 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_kiwi", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_kiwi]};
+        });
+
+        it(@"returns the CI color 'kiwi'", ^{
+            expect([UIColor trs_kiwi]).to.equal([UIColor colorWithRed:0.8 green:0.89 blue:0 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_curacao", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_curacao]};
+        });
+
+        it(@"returns the CI color 'curacao'", ^{
+            expect([UIColor trs_curacao]).to.equal([UIColor colorWithRed:0.05 green:0.745 blue:0.862 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_beere", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_beere]};
+        });
+
+        it(@"returns the CI color 'beere'", ^{
+            expect([UIColor trs_beere]).to.equal([UIColor colorWithRed:0.824 green:0 blue:0.471 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_black", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_black]};
+        });
+
+        it(@"returns the CI color 'black'", ^{
+            expect([UIColor trs_black]).to.equal([UIColor blackColor]);
+        });
+
+    });
+
+    describe(@"trs_80_gray", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_80_gray]};
+        });
+
+        it(@"returns the CI color 'gray' with 80 percent", ^{
+            expect([UIColor trs_80_gray]).to.equal([UIColor colorWithRed:0.329 green:0.337 blue:0.317 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_60_gray", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_60_gray]};
+        });
+
+        it(@"returns the CI color 'gray' with 60 percent", ^{
+            expect([UIColor trs_60_gray]).to.equal([UIColor colorWithRed:0.529 green:0.529 blue:0.501 alpha:1]);
+        });
+
+    });
+
+    describe(@"trs_white", ^{
+
+        itShouldBehaveLike(@"a UIColor object", ^{
+            return @{@"object" : [UIColor trs_white]};
+        });
+
+        it(@"returns the CI color 'white'", ^{
+            expect([UIColor trs_white]).to.equal([UIColor whiteColor]);
+        });
+
+    });
+
+});
+
+SpecEnd

--- a/Example/Trustbadge.xcodeproj/project.pbxproj
+++ b/Example/Trustbadge.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		84795A4E1B5E41A30091EA49 /* TRSNetworkAgentSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84795A4C1B5E3EDA0091EA49 /* TRSNetworkAgentSpec.m */; };
 		84795A551B5E6B800091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84795A531B5E68EC0091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m */; };
 		848CFD731B82140A00CEEE1E /* Trustbadge-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 848CFD721B82140A00CEEE1E /* Trustbadge-Info.plist */; };
+		849B99851B8B600D007EA5EB /* UIColor+TRSColorsInternalSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 849B99841B8B600D007EA5EB /* UIColor+TRSColorsInternalSpec.m */; };
 		84C2BC2F1B78C25000F54653 /* TRSTrustbadgeViewSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84C2BC2E1B78C25000F54653 /* TRSTrustbadgeViewSpec.m */; };
 		84D2C8791B678694005AE982 /* TRSTrustbadgeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D2C8781B678693005AE982 /* TRSTrustbadgeSpec.m */; };
 		EB2149F0C7BD28BFCE1F4A5B /* Pods_Trustbadge_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1CA5AD3059E7771ECEAF3C7 /* Pods_Trustbadge_Example.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -105,6 +106,7 @@
 		8485B6361B7A05AA00D22F1E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		848CFD721B82140A00CEEE1E /* Trustbadge-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Trustbadge-Info.plist"; sourceTree = "<group>"; };
 		848CFD741B82141900CEEE1E /* Trustbadge-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Trustbadge-Prefix.pch"; sourceTree = "<group>"; };
+		849B99841B8B600D007EA5EB /* UIColor+TRSColorsInternalSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+TRSColorsInternalSpec.m"; sourceTree = "<group>"; };
 		84C2BC2E1B78C25000F54653 /* TRSTrustbadgeViewSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRSTrustbadgeViewSpec.m; sourceTree = "<group>"; };
 		84D2C8781B678693005AE982 /* TRSTrustbadgeSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRSTrustbadgeSpec.m; sourceTree = "<group>"; };
 		A1CA5AD3059E7771ECEAF3C7 /* Pods_Trustbadge_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Trustbadge_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +187,7 @@
 				84D2C8781B678693005AE982 /* TRSTrustbadgeSpec.m */,
 				84C2BC2E1B78C25000F54653 /* TRSTrustbadgeViewSpec.m */,
 				845E83DC1B8323C3001D5EDC /* NSNumberFormatter+TRSFormatterSpec.m */,
+				849B99841B8B600D007EA5EB /* UIColor+TRSColorsInternalSpec.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				84795A4E1B5E41A30091EA49 /* TRSNetworkAgentSpec.m in Sources */,
 				845E62DA1B7B80D40051329C /* TRSTrustbadgeSDKPrivatSpec.m in Sources */,
 				84795A551B5E6B800091EA49 /* TRSNetworkAgent+TrustbadgeSpec.m in Sources */,
+				849B99851B8B600D007EA5EB /* UIColor+TRSColorsInternalSpec.m in Sources */,
 				84C2BC2F1B78C25000F54653 /* TRSTrustbadgeViewSpec.m in Sources */,
 				84D2C8791B678694005AE982 /* TRSTrustbadgeSpec.m in Sources */,
 			);


### PR DESCRIPTION
Increase test coverage by adding simple specs for internal colors.
