### PR TITLE
changing platform to 8.0 instead of 8.1

### DIFF
--- a/Trustbadge.podspec
+++ b/Trustbadge.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author           = "Trusted Shops GmbH"
   s.source           = { :git => "https://github.com/trustedshops/trustedshops-ios-sdk.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '8.1'
+  s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.dependency 'MaryPopin', '~> 1.4.2'


### PR DESCRIPTION
we are using a lot of platforms with minimum deployment target as 8.0, please change it to 8.0 if it does not have any implementation problems on your side.
With platform as 8.1, we are not able  to install this framework
