### PR TITLE
fixing issue of trustedwebview appearing behind presented view controller

### DIFF
--- a/Pod/Classes/Private/TRSTrustcard.m
+++ b/Pod/Classes/Private/TRSTrustcard.m
@@ -80,7 +80,14 @@ static NSString * const TRSCertHTMLName = @"trustinfos"; // not used atm
 	// TODO: check what happens if there is no root VC. work that out
 //	[rootVC presentViewController:self animated:YES completion:nil];
 	[self setPopinOptions:BKTPopinDisableAutoDismiss];
-	[rootVC presentPopinController:self animated:YES completion:nil];
+    
+    
+    if (rootVC.presentedViewController) {
+        [rootVC.presentedViewController presentPopinController:self animated:YES completion:nil];
+    }
+    else {
+        [rootVC presentPopinController:self animated:YES completion:nil];
+    }
 }
 
 #pragma mark - UIWebViewDelegate


### PR DESCRIPTION
if rootVC has presented view controller than use that, instead of using rootVC.  Due to this we are having a bug in which Trust webview card view controller is appearing below our presented view controller
